### PR TITLE
Removed squizlabs/php_codesniffer dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "zendframework/zend-modulemanager": "~2.3",
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-servicemanager": "~2.3",
-        "zfcampus/zf-api-problem": "~1.0",
-        "squizlabs/php_codesniffer": "~2.0"
+        "zfcampus/zf-api-problem": "~1.0"
     },
     "require-dev": {
         "doctrine/doctrine-mongo-odm-module": "0.*@dev",


### PR DESCRIPTION
PHP CodeSniffer dependency is causing problems with some current setups. If CodeSniffer classes aren't references in the code, that dependency should not appear. It might occur in "suggest" or "require dev", but it's still matter of CI setup, not that repository per se.