### PR TITLE
DefaultOdm query provider throws ServiceLocatorUsageException

### DIFF
--- a/src/Query/Provider/DefaultOdm.php
+++ b/src/Query/Provider/DefaultOdm.php
@@ -71,7 +71,8 @@ class DefaultOdm implements QueryProviderInterface, ServiceLocatorAwareInterface
      */
     public function createQuery(ResourceEvent $event, $entityClass, $parameters)
     {
-        $request = $this->getServiceLocator()->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
+        $request = $this->getServiceLocator()
+            ->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
 
         $queryBuilder = $this->getObjectManager()->createQueryBuilder();
         $queryBuilder->find($entityClass);

--- a/src/Query/Provider/DefaultOdm.php
+++ b/src/Query/Provider/DefaultOdm.php
@@ -71,7 +71,7 @@ class DefaultOdm implements QueryProviderInterface, ServiceLocatorAwareInterface
      */
     public function createQuery(ResourceEvent $event, $entityClass, $parameters)
     {
-        $request = $this->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
+        $request = $this->getServiceLocator()->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
 
         $queryBuilder = $this->getObjectManager()->createQueryBuilder();
         $queryBuilder->find($entityClass);


### PR DESCRIPTION
Hi there,

I am trying to integrate MongoDB with Apigility. I configured it using https://packagist.org/packages/doctrine/doctrine-mongo-odm-module and all seemed to be okay. After successfully creating the first doctrine connected rest service with doctrine odm_default, querying seems to be a problem.

The DefaultOdm query provider seems to break on the ```createQuery``` function, stating ```Service \"Application\" has been requested to plugin manager of type \"ZF\\\\Apigility\\\\Doctrine\\\\Server\\\\Query\\\\Provider\\\\Service\\\\QueryProviderManager\", but couldn't be retrieved.\\\nA previous exception of type \"Zend\\\\ServiceManager\\\\Exception\\\\ServiceNotFoundException\" has been raised in the process.\\\nBy the way, a service with the name \"Application\" has been found in the parent service locator \"Zend\\\\ServiceManager\\\\ServiceManager\": did you forget to use $parentLocator = $serviceLocator->getServiceLocator() in your factory code?```

Changing the code from
```
    /**
     * {@inheritDoc}
     */
    public function createQuery(ResourceEvent $event, $entityClass, $parameters)
    {
        $request = $this->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
        **snip**
```

to 
```
    /**
     * {@inheritDoc}
     */
    public function createQuery(ResourceEvent $event, $entityClass, $parameters)
    {
        $request = $this->getServiceLocator()->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
        **snip**
```

seems to fix it, but am curious if this is any wrongdoing on my part or a bug?

Regards,
Lennart