### PR TITLE
Get metadata for specific entity class when creating query.

### DIFF
--- a/src/Query/Provider/DefaultOdm.php
+++ b/src/Query/Provider/DefaultOdm.php
@@ -78,23 +78,23 @@ class DefaultOdm implements QueryProviderInterface, ServiceLocatorAwareInterface
         $queryBuilder->find($entityClass);
 
         if (isset($request[$this->getFilterKey()])) {
-            $metadata = $this->getObjectManager()->getMetadataFactory()->getAllMetadata();
+            $metadata = $this->getObjectManager()->getMetadataFactory()->getMetadataFor($entityClass);
             $filterManager = $this->getServiceLocator()
                 ->getServiceLocator()->get('ZfDoctrineQueryBuilderFilterManagerOdm');
             $filterManager->filter(
                 $queryBuilder,
-                $metadata[0],
+                $metadata,
                 $request[$this->getFilterKey()]
             );
         }
 
         if (isset($request[$this->getOrderByKey()])) {
-            $metadata = $this->getObjectManager()->getMetadataFactory()->getAllMetadata();
+            $metadata = $this->getObjectManager()->getMetadataFactory()->getMetadataFor($entityClass);
             $orderByManager = $this->getServiceLocator()
                 ->getServiceLocator()->get('ZfDoctrineQueryBuilderOrderByManagerOdm');
             $orderByManager->orderBy(
                 $queryBuilder,
-                $metadata[0],
+                $metadata,
                 $request[$this->getOrderByKey()]
             );
         }


### PR DESCRIPTION
Currently when fetching meta data for an ODM entity the method createQuery() uses the getAllMetadata() methods from the MetadataFactory object and then opts to use the first key (0) as the mapping to be passed to the filter manager. However the first key doesn't necessarily hold the correct mapping data. For example if an entity extends an abstract class then the abstract class meta data will be returned. This leads to fieldMappings being absent from computation in the filter.

A good example is the typeCaseField method which uses a try/catch switch to determine the type, however when the entity extends other classes as per my example above, then the fieldMappings for the given field aren't necessarily in the meta data (for example they are only declared in the entity and not the extended classes).

I propose to use the getMetadataFor() methods of the metadataFactory class to fetch specific meta data for the given entity class.

https://github.com/zfcampus/zf-doctrine-querybuilder/pull/29/files

