### PR TITLE
Hotfix #33 - `DefaultO*mFactory` fix (ZF2 compatibility)

### DIFF
--- a/src/Query/Provider/DefaultOdmFactory.php
+++ b/src/Query/Provider/DefaultOdmFactory.php
@@ -7,6 +7,7 @@
 namespace ZF\Doctrine\QueryBuilder\Query\Provider;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 
 class DefaultOdmFactory
 {
@@ -18,6 +19,10 @@ class DefaultOdmFactory
      */
     public function __invoke(ContainerInterface $container)
     {
+        if ($container instanceof AbstractPluginManager) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
         $provider = new DefaultOdm();
         $provider->setServiceLocator($container);
 

--- a/src/Query/Provider/DefaultOrmFactory.php
+++ b/src/Query/Provider/DefaultOrmFactory.php
@@ -7,6 +7,7 @@
 namespace ZF\Doctrine\QueryBuilder\Query\Provider;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 
 class DefaultOrmFactory
 {
@@ -18,6 +19,10 @@ class DefaultOrmFactory
      */
     public function __invoke(ContainerInterface $container)
     {
+        if ($container instanceof AbstractPluginManager) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
         $provider = new DefaultOrm();
         $provider->setServiceLocator($container);
 

--- a/test/Query/Provider/DefaultOdmFactoryTest.php
+++ b/test/Query/Provider/DefaultOdmFactoryTest.php
@@ -7,6 +7,7 @@
 namespace ZFTest\Doctrine\QueryBuilder\Query\Provider;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\Doctrine\QueryBuilder\Query\Provider\DefaultOdm;
 use ZF\Doctrine\QueryBuilder\Query\Provider\DefaultOdmFactory;
@@ -19,6 +20,19 @@ class DefaultOdmFactoryTest extends TestCase
 
         $factory = new DefaultOdmFactory();
         $provider = $factory($serviceLocator);
+
+        $this->assertInstanceOf(DefaultOdm::class, $provider);
+        $this->assertAttributeSame($serviceLocator, 'serviceLocator', $provider);
+    }
+
+    public function testInvokableFactoryReturnsDefaultOdmQueryProviderWhenCreatedViaAbstractPluginManager()
+    {
+        $serviceLocator = $this->prophesize(ServiceLocatorInterface::class)->reveal();
+        $abstractPluginManager = $this->prophesize(AbstractPluginManager::class);
+        $abstractPluginManager->getServiceLocator()->willReturn($serviceLocator);
+
+        $factory = new DefaultOdmFactory();
+        $provider = $factory($abstractPluginManager->reveal());
 
         $this->assertInstanceOf(DefaultOdm::class, $provider);
         $this->assertAttributeSame($serviceLocator, 'serviceLocator', $provider);

--- a/test/Query/Provider/DefaultOrmFactoryTest.php
+++ b/test/Query/Provider/DefaultOrmFactoryTest.php
@@ -7,6 +7,7 @@
 namespace ZFTest\Doctrine\QueryBuilder\Query\Provider;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\Doctrine\QueryBuilder\Query\Provider\DefaultOrm;
 use ZF\Doctrine\QueryBuilder\Query\Provider\DefaultOrmFactory;
@@ -19,6 +20,19 @@ class DefaultOrmFactoryTest extends TestCase
 
         $factory = new DefaultOrmFactory();
         $provider = $factory($serviceLocator);
+
+        $this->assertInstanceOf(DefaultOrm::class, $provider);
+        $this->assertAttributeSame($serviceLocator, 'serviceLocator', $provider);
+    }
+
+    public function testInvokableFactoryReturnsDefaultOrmQueryProviderWhenCreatedViaAbstractPluginManager()
+    {
+        $serviceLocator = $this->prophesize(ServiceLocatorInterface::class)->reveal();
+        $abstractPluginManager = $this->prophesize(AbstractPluginManager::class);
+        $abstractPluginManager->getServiceLocator()->willReturn($serviceLocator);
+
+        $factory = new DefaultOrmFactory();
+        $provider = $factory($abstractPluginManager->reveal());
 
         $this->assertInstanceOf(DefaultOrm::class, $provider);
         $this->assertAttributeSame($serviceLocator, 'serviceLocator', $provider);


### PR DESCRIPTION
`DefaultOdmFactory` and `DefaultOrmFactory` could be used with context of `AbstractPluginManager`
- with ZF2 and `zf-apigility-doctrine` these factories are used with
`ZF\Apigility\Doctrine\Server\Query\Provider\Service\QueryProviderManager`