### PR TITLE
Use metadata to verify order by field exists on row entity

### DIFF
--- a/src/OrderBy/ORM/Field.php
+++ b/src/OrderBy/ORM/Field.php
@@ -20,6 +20,10 @@ class Field extends AbstractOrderBy
             throw new Exception('Invalid direction in orderby directive');
         }
 
+        if ($option['alias'] == 'row' && ! isset($metadata->fieldMappings[$option['field']])) {
+            return;
+        }
+
         $queryBuilder->addOrderBy($option['alias'] . '.' . $option['field'], $option['direction']);
     }
 }

--- a/test/OrderBy/ORMOrderByTest.php
+++ b/test/OrderBy/ORMOrderByTest.php
@@ -100,4 +100,20 @@ class ORMOrderByTest extends TestCase
 
         $this->assertEquals('ABBA', $artist->getName());
     }
+
+    public function testFieldFailsQuietlyWithInvalidFieldName()
+    {
+        $orderBy = [
+            [
+                'type' => 'field',
+                'field' => 'invalid',
+                'direction' => 'desc',
+            ],
+        ];
+
+        $result = $this->fetchResult($orderBy);
+        $artist = reset($result);
+
+        $this->assertEquals('ABBA', $artist->getName());
+    }
 }


### PR DESCRIPTION
For the row alias only validate the field exists in the metadata.

This only checks the metadata for the 'row' alias.  It would be nice to validate inner join aliases' metadata too in the future.