### PR TITLE
Use protected methods in Query Providers

### DIFF
--- a/src/Query/Provider/DefaultOdm.php
+++ b/src/Query/Provider/DefaultOdm.php
@@ -128,7 +128,7 @@ class DefaultOdm extends AbstractQueryProvider implements QueryProviderInterface
     /**
      * @return array
      */
-    private function getConfig()
+    protected function getConfig()
     {
         $config = $this->getServiceLocator()->get('config');
         if (isset($config['zf-doctrine-querybuilder-options'])) {
@@ -141,7 +141,7 @@ class DefaultOdm extends AbstractQueryProvider implements QueryProviderInterface
     /**
      * @return ODMFilterManager
      */
-    private function getFilterManager()
+    protected function getFilterManager()
     {
         return $this->getServiceLocator()->get(ODMFilterManager::class);
     }
@@ -149,7 +149,7 @@ class DefaultOdm extends AbstractQueryProvider implements QueryProviderInterface
     /**
      * @return ODMOrderByManager
      */
-    private function getOrderByManager()
+    protected function getOrderByManager()
     {
         return $this->getServiceLocator()->get(ODMOrderByManager::class);
     }

--- a/src/Query/Provider/DefaultOrm.php
+++ b/src/Query/Provider/DefaultOrm.php
@@ -103,7 +103,7 @@ class DefaultOrm extends AbstractQueryProvider implements QueryProviderInterface
     /**
      * @return array
      */
-    private function getConfig()
+    protected function getConfig()
     {
         $config = $this->getServiceLocator()->get('config');
         if (isset($config['zf-doctrine-querybuilder-options'])) {
@@ -116,7 +116,7 @@ class DefaultOrm extends AbstractQueryProvider implements QueryProviderInterface
     /**
      * @return ORMFilterManager
      */
-    private function getFilterManager()
+    protected function getFilterManager()
     {
         return $this->getServiceLocator()->get(ORMFilterManager::class);
     }
@@ -124,7 +124,7 @@ class DefaultOrm extends AbstractQueryProvider implements QueryProviderInterface
     /**
      * @return ORMOrderByManager
      */
-    private function getOrderByManager()
+    protected function getOrderByManager()
     {
         return $this->getServiceLocator()->get(ORMOrderByManager::class);
     }


### PR DESCRIPTION
When the DefaultOrm Query Provider is extended and the default createQuery function is not called, instead opting to run the filters directly, the functions to fetch the managers are private and cannot be accessed.

This PR changes any private functions on Query Providers to public.