### PR TITLE
Fix odm isnull isnotnull

### DIFF
--- a/src/Filter/ODM/IsNotNull.php
+++ b/src/Filter/ODM/IsNotNull.php
@@ -19,6 +19,6 @@ class IsNotNull extends AbstractFilter
             }
         }
 
-        $queryBuilder->$queryType($queryBuilder->expr()->field($option['field'])->exists(true));
+        $queryBuilder->$queryType($queryBuilder->expr()->field($option['field'])->notEqual(null));
     }
 }

--- a/src/Filter/ODM/IsNull.php
+++ b/src/Filter/ODM/IsNull.php
@@ -19,6 +19,6 @@ class IsNull extends AbstractFilter
             }
         }
 
-        $queryBuilder->$queryType($queryBuilder->expr()->field($option['field'])->exists(false));
+        $queryBuilder->$queryType($queryBuilder->expr()->field($option['field'])->equals(null));
     }
 }

--- a/test/Filter/ODMFilterTest.php
+++ b/test/Filter/ODMFilterTest.php
@@ -48,16 +48,19 @@ class ODMFilterTest extends TestCase
 
         $meta1 = new Document\Meta;
         $meta1->setName('MetaOne');
+        $meta1->setDescription('Foo');
         $meta1->setCreatedAt(new DateTime('2011-12-18 13:17:17'));
         $objectManager->persist($meta1);
 
         $meta2 = new Document\Meta;
         $meta2->setName('MetaTwo');
+        $meta2->setDescription('Bar');
         $meta2->setCreatedAt(new DateTime('2014-12-18 13:17:17'));
         $objectManager->persist($meta2);
 
         $meta3 = new Document\Meta;
         $meta3->setName('MetaThree');
+        $meta3->setDescription('Baz');
         $meta3->setCreatedAt(new DateTime('2012-12-18 13:17:17'));
         $objectManager->persist($meta3);
 
@@ -370,7 +373,6 @@ class ODMFilterTest extends TestCase
 
         $this->assertEquals(1, $this->countResult($filters));
 
-
         $filters = [
             [
                 'field' => 'createdAt',
@@ -381,6 +383,29 @@ class ODMFilterTest extends TestCase
 
         $this->assertEquals(1, $this->countResult($filters));
 
+        $filters = [
+            [
+                'field' => 'description',
+                'type' => 'isnull',
+            ],
+        ];
+
+        $this->assertEquals(2, $this->countResult($filters));
+
+        $filters = [
+            [
+                'field' => 'description',
+                'where' => 'and',
+                'type' => 'isnull',
+            ],
+            [
+                'field' => 'createdAt',
+                'where' => 'and',
+                'type' => 'isnull',
+            ],
+        ];
+
+        $this->assertEquals(1, $this->countResult($filters));
 
         $filters = [
             [
@@ -397,6 +422,15 @@ class ODMFilterTest extends TestCase
         ];
 
         $this->assertEquals(2, $this->countResult($filters));
+
+        $filters = [
+            [
+                'field' => 'nonExistingField',
+                'type' => 'isnull',
+            ],
+        ];
+
+        $this->assertEquals(5, $this->countResult($filters));
     }
 
     public function testIsNotNull()
@@ -410,7 +444,6 @@ class ODMFilterTest extends TestCase
 
         $this->assertEquals(4, $this->countResult($filters));
 
-
         $filters = [
             [
                 'field' => 'createdAt',
@@ -421,6 +454,29 @@ class ODMFilterTest extends TestCase
 
         $this->assertEquals(4, $this->countResult($filters));
 
+        $filters = [
+            [
+                'field' => 'description',
+                'type' => 'isnotnull',
+            ],
+        ];
+
+        $this->assertEquals(3, $this->countResult($filters));
+
+        $filters = [
+            [
+                'field' => 'description',
+                'where' => 'and',
+                'type' => 'isnotnull',
+            ],
+            [
+                'field' => 'createdAt',
+                'where' => 'and',
+                'type' => 'isnotnull',
+            ],
+        ];
+
+        $this->assertEquals(3, $this->countResult($filters));
 
         $filters = [
             [
@@ -437,6 +493,15 @@ class ODMFilterTest extends TestCase
         ];
 
         $this->assertEquals(5, $this->countResult($filters));
+
+        $filters = [
+            [
+                'field' => 'nonExistingField',
+                'type' => 'isnotnull',
+            ],
+        ];
+
+        $this->assertEquals(0, $this->countResult($filters));
     }
 
     public function testIn()

--- a/test/assets/module/DbMongo/config/yml/DbMongo.Document.Meta.dcm.yml
+++ b/test/assets/module/DbMongo/config/yml/DbMongo.Document.Meta.dcm.yml
@@ -7,5 +7,8 @@ DbMongo\Document\Meta:
       id: true
     name:
       type: string
+    description:
+      type: string
+      nullable: true
     createdAt:
       type: date

--- a/test/assets/module/DbMongo/src/DbMongo/Document/Meta.php
+++ b/test/assets/module/DbMongo/src/DbMongo/Document/Meta.php
@@ -37,11 +37,24 @@ class Meta
         $this->createdAt = $value;
     }
 
+    protected $description;
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function setDescription($value)
+    {
+        $this->description = $value;
+    }
+
     public function getArrayCopy()
     {
         return [
             'name' => $this->getName(),
             'createdAt' => $this->getCreatedAt(),
+            'description' => $this->getDescription(),
         ];
     }
 


### PR DESCRIPTION
Update for the ODM isNull filter to match fields that contain nulls, not just fields that don't exist. ODM documents may contain nulls via the "nullable" option. This change covers both the case where the field is null or where the field doesn't exist. isNotNull is also updated to provide the complementary behavior.