### PR TITLE
fix filtering of joined/referenced fields, add custom types support

### DIFF
--- a/src/Filter/ORM/Between.php
+++ b/src/Filter/ORM/Between.php
@@ -26,10 +26,13 @@ class Between extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
-        $from = $this->typeCastField($metadata, $option['field'], $option['from'], $format);
-        $to = $this->typeCastField($metadata, $option['field'], $option['to'], $format);
+        $from = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['from'], $format);
+        $to = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['to'], $format);
 
         $fromParameter = uniqid('a1');
         $toParameter = uniqid('a2');
@@ -43,7 +46,7 @@ class Between extends AbstractFilter
                     sprintf(':%s', $toParameter)
                 )
         );
-        $queryBuilder->setParameter($fromParameter, $from);
-        $queryBuilder->setParameter($toParameter, $to);
+        $queryBuilder->setParameter($fromParameter, $from, $fieldType);
+        $queryBuilder->setParameter($toParameter, $to, $fieldType);
     }
 }

--- a/src/Filter/ORM/Equals.php
+++ b/src/Filter/ORM/Equals.php
@@ -26,12 +26,15 @@ class Equals extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = null;
         if (isset($option['format'])) {
             $format = $option['format'];
         }
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -39,6 +42,6 @@ class Equals extends AbstractFilter
                 ->expr()
                 ->eq($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/GreaterThan.php
+++ b/src/Filter/ORM/GreaterThan.php
@@ -26,9 +26,12 @@ class GreaterThan extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -36,6 +39,6 @@ class GreaterThan extends AbstractFilter
                 ->expr()
                 ->gt($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/GreaterThanOrEquals.php
+++ b/src/Filter/ORM/GreaterThanOrEquals.php
@@ -26,9 +26,12 @@ class GreaterThanOrEquals extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -36,6 +39,6 @@ class GreaterThanOrEquals extends AbstractFilter
                 ->expr()
                 ->gte($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/In.php
+++ b/src/Filter/ORM/In.php
@@ -26,13 +26,16 @@ class In extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
         $queryValues = [];
         foreach ($option['values'] as $value) {
             $queryValues[] = $this->typeCastField(
-                $metadata,
-                $option['field'],
+                $typeCastMetaData,
+                $typeCastFieldName,
                 $value,
                 $format,
                 $doNotTypecastDatetime = true
@@ -45,6 +48,6 @@ class In extends AbstractFilter
                 ->expr()
                 ->in($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $queryValues);
+        $queryBuilder->setParameter($parameter, $queryValues, $fieldType);
     }
 }

--- a/src/Filter/ORM/IsMemberOf.php
+++ b/src/Filter/ORM/IsMemberOf.php
@@ -31,12 +31,15 @@ class IsMemberOf extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = null;
         if (isset($option['format'])) {
             $format = $option['format'];
         }
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -44,6 +47,6 @@ class IsMemberOf extends AbstractFilter
                 ->expr()
                 ->isMemberOf(':' . $parameter, $option['alias'] . '.' . $option['field'])
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/LessThan.php
+++ b/src/Filter/ORM/LessThan.php
@@ -26,12 +26,15 @@ class LessThan extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = null;
         if (isset($option['format'])) {
             $format = $option['format'];
         }
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -39,6 +42,6 @@ class LessThan extends AbstractFilter
                 ->expr()
                 ->lt($option['alias'] . '.' . $option['field'], ":$parameter")
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/LessThanOrEquals.php
+++ b/src/Filter/ORM/LessThanOrEquals.php
@@ -26,9 +26,12 @@ class LessThanOrEquals extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -36,6 +39,6 @@ class LessThanOrEquals extends AbstractFilter
                 ->expr()
                 ->lte($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/NotEquals.php
+++ b/src/Filter/ORM/NotEquals.php
@@ -26,9 +26,12 @@ class NotEquals extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
-        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        $value = $this->typeCastField($typeCastMetaData, $typeCastFieldName, $option['value'], $format);
 
         $parameter = uniqid('a');
         $queryBuilder->$queryType(
@@ -36,6 +39,6 @@ class NotEquals extends AbstractFilter
                 ->expr()
                 ->neq($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $value);
+        $queryBuilder->setParameter($parameter, $value, $fieldType);
     }
 }

--- a/src/Filter/ORM/NotIn.php
+++ b/src/Filter/ORM/NotIn.php
@@ -26,13 +26,16 @@ class NotIn extends AbstractFilter
             $option['alias'] = 'row';
         }
 
+        [$typeCastMetaData, $typeCastFieldName] = $this->getTypeCastParams($queryBuilder, $metadata, $option['field'], $option['alias']);
+        $fieldType = $typeCastMetaData->getTypeOfField($typeCastFieldName);
+
         $format = isset($option['format']) ? $option['format'] : null;
 
         $queryValues = [];
         foreach ($option['values'] as $value) {
             $queryValues[] = $this->typeCastField(
-                $metadata,
-                $option['field'],
+                $typeCastMetaData,
+                $typeCastFieldName,
                 $value,
                 $format,
                 $doNotTypecastDatetime = true
@@ -45,6 +48,6 @@ class NotIn extends AbstractFilter
                 ->expr()
                 ->notIn($option['alias'] . '.' . $option['field'], ':' . $parameter)
         );
-        $queryBuilder->setParameter($parameter, $queryValues);
+        $queryBuilder->setParameter($parameter, $queryValues, $fieldType);
     }
 }


### PR DESCRIPTION
1) typeCastField() is not used correctly for reference fields and joined entity fields
because of wrong $metadata object usage

2) filters doesn't support custom data types
added $fieldType passing to setParameter();