### PR TITLE
Allow usage with zend-hydrator v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - LEGACY_DEPS="doctrine/doctrine-module doctrine/doctrine-orm-module phpunit/phpunit"
+        - LEGACY_DEPS="doctrine/doctrine-module doctrine/doctrine-orm-module phpunit/phpunit zendframework/zend-hydrator zfcampus/zf-apigility-doctrine"
     - php: 5.6
       env:
         - DEPS=latest
@@ -35,7 +35,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - LEGACY_DEPS="doctrine/doctrine-module doctrine/doctrine-orm-module phpunit/phpunit"
+        - LEGACY_DEPS="doctrine/doctrine-module doctrine/doctrine-orm-module phpunit/phpunit zendframework/zend-hydrator zfcampus/zf-apigility-doctrine"
         - MONGO_DRIVER=mongodb
     - php: 7
       env:
@@ -48,6 +48,7 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
+        - LEGACY_DEPS="zendframework/zend-hydrator"
         - CS_CHECK=true
         - TEST_COVERAGE=true
         - MONGO_DRIVER=mongodb

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "doctrine/doctrine-module": "^1.2",
-        "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
+        "zendframework/zend-hydrator": "^1.1 || ^2.2.1 || ^3.0",
         "zendframework/zend-modulemanager": "^2.7.2",
         "zendframework/zend-mvc": "^2.7.13 || ^3.0.2",
         "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
         "doctrine/doctrine-orm-module": "^1.1, if you wish to use the Doctrine ORM"
     },
     "autoload": {
+        "files": [
+            "src/_autoload.php"
+        ],
         "psr-4": {
             "ZF\\Doctrine\\QueryBuilder\\": "src/"
         }

--- a/src/Hydrator/Strategy/CollectionLinkHydratorV2.php
+++ b/src/Hydrator/Strategy/CollectionLinkHydratorV2.php
@@ -15,9 +15,12 @@ use ZF\Hal\Link\Link;
 /**
  * A field-specific hydrator for collections.
  *
+ * This version is for use with zend-hyrator versions 1 and 2, and will be
+ * aliased to CollectionLink in those versions.
+ *
  * @returns Link
  */
-class CollectionLink extends AbstractCollectionStrategy implements StrategyInterface
+class CollectionLinkHydratorV2 extends AbstractCollectionStrategy implements StrategyInterface
 {
     protected $serviceManager;
 

--- a/src/Hydrator/Strategy/CollectionLinkHydratorV3.php
+++ b/src/Hydrator/Strategy/CollectionLinkHydratorV3.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Doctrine\QueryBuilder\Hydrator\Strategy;
+
+use DoctrineModule\Stdlib\Hydrator\Strategy\AbstractCollectionStrategy;
+use Zend\Filter\FilterChain;
+use Zend\Hydrator\Strategy\StrategyInterface;
+use Zend\ServiceManager\ServiceManager;
+use ZF\Hal\Link\Link;
+
+/**
+ * A field-specific hydrator for collections.
+ *
+ * This version is for use with zend-hyrator v3 and up, and will be aliased to
+ * CollectionLink in those versions.
+ */
+class CollectionLinkHydratorV3 extends AbstractCollectionStrategy implements StrategyInterface
+{
+    protected $serviceManager;
+
+    public function setServiceManager(ServiceManager $serviceManager)
+    {
+        $this->serviceManager = $serviceManager;
+
+        return $this;
+    }
+
+    public function getServiceManager()
+    {
+        return $this->serviceManager;
+    }
+
+    public function extract($value, ?object $object = null)
+    {
+        $config = $this->getServiceManager()->get('config');
+        if (! method_exists($value, 'getTypeClass')
+            || ! isset($config['zf-hal']['metadata_map'][$value->getTypeClass()->name])
+        ) {
+            return;
+        }
+
+        $config = $config['zf-hal']['metadata_map'][$value->getTypeClass()->name];
+        $mapping = $value->getMapping();
+
+        $filter = new FilterChain();
+        $filter->attachByName('WordCamelCaseToUnderscore')
+            ->attachByName('StringToLower');
+
+        $link = new Link($filter($mapping['fieldName']));
+        $link->setRoute($config['route_name']);
+        $link->setRouteParams(['id' => null]);
+
+        if (isset($config['zf-doctrine-querybuilder-options']['filter_key'])) {
+            $filterKey = $config['zf-doctrine-querybuilder-options']['filter_key'];
+        } else {
+            $filterKey = 'filter';
+        }
+
+        $filterValue = [
+            'field' => $mapping['mappedBy'] ? : $mapping['inversedBy'],
+            'type' => isset($mapping['joinTable']) ? 'ismemberof' : 'eq',
+            'value' => $value->getOwner()->getId(),
+        ];
+
+        $link->setRouteOptions([
+            'query' => [
+                $filterKey => [
+                    $filterValue,
+                ],
+            ],
+        ]);
+
+        return $link;
+    }
+
+    public function hydrate($value, ?array $data = null)
+    {
+        // Hydration is not supported for collections.
+        // A call to PATCH will use hydration to extract then hydrate
+        // an entity. In this process a collection will be included
+        // so no error is thrown here.
+    }
+}

--- a/src/_autoload.php
+++ b/src/_autoload.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Doctrine\QueryBuilder;
+
+use Zend\Hydrator\HydratorPluginManagerInterface;
+
+/**
+ * Alias ZF\Hal\Extractor\EntityExtractor to the appropriate class based on
+ * which version of zend-hydrator we detect. HydratorPluginManagerInterface
+ * is added in v3.
+ */
+if (interface_exists(HydratorPluginManagerInterface::class, true)) {
+    class_alias(Hydrator\Strategy\CollectionLinkHydratorV3::class, Hydrator\Strategy\CollectionLink::class, true);
+} else {
+    class_alias(Hydrator\Strategy\CollectionLinkHydratorV2::class, Hydrator\Strategy\CollectionLink::class, true);
+}


### PR DESCRIPTION
Updates dependency constraints to also allow v3 releases of zend-hydrator.  Updates the travis configuration to add zend-hydrator as a legacy dep for locked environments prior to PHP 7.2.

Additionally, this patch renames `CollectionLink` to `CollectionLinkHydratorV2`, and adds `CollectionLinkHydratorV3`, which provides an alternate version that satisfies the `StrategyInterface` definitions in zend-hydrator v3.

A new package autoloader definition will alias one of these to `CollectionLink` based on the zend-hydrator version detected.