### PR TITLE
Extract type cast behaviour

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -6,6 +6,8 @@
 
 namespace ZF\Doctrine\QueryBuilder;
 
+use Zend\ServiceManager\Factory\InvokableFactory;
+
 return [
     'service_manager' => [
         'aliases' => [
@@ -19,6 +21,8 @@ return [
             Filter\Service\ODMFilterManager::class => Filter\Service\ODMFilterManagerFactory::class,
             OrderBy\Service\ORMOrderByManager::class => OrderBy\Service\ORMOrderByManagerFactory::class,
             OrderBy\Service\ODMOrderByManager::class => OrderBy\Service\ODMOrderByManagerFactory::class,
+            Filter\ORM\TypeCaster::class => InvokableFactory::class,
+            Filter\ODM\TypeCaster::class => InvokableFactory::class,
         ],
     ],
 ];

--- a/src/Filter/ODM/AbstractFilter.php
+++ b/src/Filter/ODM/AbstractFilter.php
@@ -6,74 +6,39 @@
 
 namespace ZF\Doctrine\QueryBuilder\Filter\ODM;
 
-use DateTime;
 use ZF\Doctrine\QueryBuilder\Filter\FilterInterface;
+use ZF\Doctrine\QueryBuilder\Filter\TypeCastInterface;
 
 abstract class AbstractFilter implements FilterInterface
 {
     abstract public function filter($queryBuilder, $metadata, $option);
 
+    protected $typeCaster;
+
+    public function __construct($params)
+    {
+        if (isset($params[1])) {
+            $this->setTypeCaster($params[1]);
+        }
+    }
+
+    public function getTypeCaster()
+    {
+        if ($this->typeCaster === null) {
+            $this->typeCaster = new TypeCaster();
+        }
+
+        return $this->typeCaster;
+    }
+
+    public function setTypeCaster(TypeCastInterface $typeCaster)
+    {
+        $this->typeCaster = $typeCaster;
+        return $this;
+    }
+
     protected function typeCastField($metadata, $field, $value, $format = null, $doNotTypecastDatetime = false)
     {
-        if (! isset($metadata->fieldMappings[$field])) {
-            return $value;
-        }
-
-        switch ($metadata->fieldMappings[$field]['type']) {
-            case 'int':
-                settype($value, 'integer');
-                break;
-            case 'boolean':
-                settype($value, 'boolean');
-                break;
-            case 'float':
-                settype($value, 'float');
-                break;
-            case 'string':
-                settype($value, 'string');
-                break;
-            case 'bin_data_custom':
-                break;
-            case 'bin_data_func':
-                break;
-            case 'bin_data_md5':
-                break;
-            case 'bin_data':
-                break;
-            case 'bin_data_uuid':
-                break;
-            case 'collection':
-                break;
-            case 'custom_id':
-                break;
-            case 'date':
-                if ($value && ! $doNotTypecastDatetime) {
-                    if (! $format) {
-                        $format = 'Y-m-d H:i:s';
-                    }
-                    $value = DateTime::createFromFormat($format, $value);
-                }
-                break;
-            case 'file':
-                break;
-            case 'hash':
-                break;
-            case 'id':
-                break;
-            case 'increment':
-                break;
-            case 'key':
-                break;
-            case 'object_id':
-                break;
-            case 'raw_type':
-                break;
-            case 'timestamp':
-                break;
-            default:
-                break;
-        }
-
-        return $value;
+        return $this->getTypeCaster()->typeCastField($metadata, $field, $value, $format, $doNotTypecastDatetime);
     }
 }

--- a/src/Filter/ODM/TypeCaster.php
+++ b/src/Filter/ODM/TypeCaster.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Doctrine\QueryBuilder\Filter\ODM;
+
+use DateTime;
+use ZF\Doctrine\QueryBuilder\Filter\TypeCastInterface;
+
+class TypeCaster implements TypeCastInterface
+{
+    public function typeCastField($metadata, $field, $value, $format = null, $doNotTypecastDatetime = false)
+    {
+        if (! isset($metadata->fieldMappings[$field])) {
+            return $value;
+        }
+
+        switch ($metadata->fieldMappings[$field]['type']) {
+            case 'int':
+                settype($value, 'integer');
+                break;
+            case 'boolean':
+                settype($value, 'boolean');
+                break;
+            case 'float':
+                settype($value, 'float');
+                break;
+            case 'string':
+                settype($value, 'string');
+                break;
+            case 'bin_data_custom':
+                break;
+            case 'bin_data_func':
+                break;
+            case 'bin_data_md5':
+                break;
+            case 'bin_data':
+                break;
+            case 'bin_data_uuid':
+                break;
+            case 'collection':
+                break;
+            case 'custom_id':
+                break;
+            case 'date':
+                if ($value && ! $doNotTypecastDatetime) {
+                    if (! $format) {
+                        $format = 'Y-m-d H:i:s';
+                    }
+                    $value = DateTime::createFromFormat($format, $value);
+                }
+                break;
+            case 'file':
+                break;
+            case 'hash':
+                break;
+            case 'id':
+                break;
+            case 'increment':
+                break;
+            case 'key':
+                break;
+            case 'object_id':
+                break;
+            case 'raw_type':
+                break;
+            case 'timestamp':
+                break;
+            default:
+                break;
+        }
+
+        return $value;
+    }
+}

--- a/src/Filter/ORM/TypeCaster.php
+++ b/src/Filter/ORM/TypeCaster.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Doctrine\QueryBuilder\Filter\ORM;
+
+use DateTime;
+use ZF\Doctrine\QueryBuilder\Filter\TypeCastInterface;
+
+class TypeCaster implements TypeCastInterface
+{
+    public function typeCastField($metadata, $field, $value, $format = null, $doNotTypecastDatetime = false)
+    {
+        if (! isset($metadata->fieldMappings[$field])) {
+            return $value;
+        }
+
+        switch ($metadata->fieldMappings[$field]['type']) {
+            case 'string':
+                settype($value, 'string');
+                break;
+            case 'integer':
+            case 'smallint':
+                #case 'bigint':  // Don't try to manipulate bigints?
+                settype($value, 'integer');
+                break;
+            case 'boolean':
+                settype($value, 'boolean');
+                break;
+            case 'decimal':
+            case 'float':
+                settype($value, 'float');
+                break;
+            case 'date':
+                // For dates set time to midnight
+                if ($value && ! $doNotTypecastDatetime) {
+                    if (! $format) {
+                        $format = 'Y-m-d';
+                    }
+                    $value = DateTime::createFromFormat($format, $value);
+                    $value = DateTime::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d') . ' 00:00:00');
+                }
+                break;
+            case 'time':
+                if ($value && ! $doNotTypecastDatetime) {
+                    if (! $format) {
+                        $format = 'H:i:s';
+                    }
+                    $value = DateTime::createFromFormat($format, $value);
+                }
+                break;
+            case 'datetime':
+                if ($value && ! $doNotTypecastDatetime) {
+                    if (! $format) {
+                        $format = 'Y-m-d H:i:s';
+                    }
+                    $value = DateTime::createFromFormat($format, $value);
+                }
+                break;
+            default:
+                break;
+        }
+
+        return $value;
+    }
+}

--- a/src/Filter/Service/ODMFilterManager.php
+++ b/src/Filter/Service/ODMFilterManager.php
@@ -12,6 +12,7 @@ use RuntimeException;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception;
 use ZF\Doctrine\QueryBuilder\Filter\FilterInterface;
+use ZF\Doctrine\QueryBuilder\Filter\ODM\TypeCaster;
 
 class ODMFilterManager extends AbstractPluginManager
 {
@@ -27,7 +28,9 @@ class ODMFilterManager extends AbstractPluginManager
                 throw new RuntimeException('Array element "type" is required for all filters');
             }
 
-            $filter = $this->get(strtolower($option['type']), [$this]);
+            $typeCaster = $this->resolveTypeCaster();
+
+            $filter = $this->get(strtolower($option['type']), [$this, $typeCaster]);
             $filter->filter($queryBuilder, $metadata, $option);
         }
     }
@@ -69,5 +72,18 @@ class ODMFilterManager extends AbstractPluginManager
         } catch (Exception\InvalidServiceException $e) {
             throw new Exception\InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    protected function resolveTypeCaster()
+    {
+        if (\property_exists($this, 'creationContext')) {
+            $serviceLocator = $this->creationContext;
+        } else {
+            $serviceLocator = $this->getServiceLocator();
+        }
+
+        $typeCaster = $serviceLocator->get(TypeCaster::class);
+
+        return $typeCaster;
     }
 }

--- a/src/Filter/TypeCastInterface.php
+++ b/src/Filter/TypeCastInterface.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Doctrine\QueryBuilder\Filter;
+
+interface TypeCastInterface
+{
+    public function typeCastField($metadata, $field, $value, $format = null, $doNotTypecastDatetime = false);
+}

--- a/test/Filter/ODMTypeCasterTest.php
+++ b/test/Filter/ODMTypeCasterTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Doctrine\QueryBuilder\Filter;
+
+use PHPUnit\Framework\TestCase;
+use ZF\Doctrine\QueryBuilder\Filter\ODM\TypeCaster;
+
+class ODMTypeCasterTest extends TestCase
+{
+    private $typeCaster;
+
+    protected function setUp()
+    {
+        $this->typeCaster = new TypeCaster();
+    }
+
+    public function testTypeCastingToInteger()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'int'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2144211244';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(2144211244, $result);
+    }
+
+    public function testTypeCastingToBoolean()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'boolean'
+            ],
+        ];
+
+        $field = 'field';
+        $value = 'abc';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(true, $result);
+
+        $value = 0;
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(false, $result);
+    }
+
+    public function testTypeCastingToFloat()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'float'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '1.242';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(1.242, $result);
+    }
+
+    public function testTypeCastingToString()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'string'
+            ],
+        ];
+
+        $field = 'field';
+        $value = 1;
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+
+        $this->assertSame('1', $result);
+    }
+
+    public function testTypeCastingToDate()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'date'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01 12:19:01';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertEquals($result->format('Y-m-d H:i:s'), '2019-09-01 12:19:01');
+    }
+
+    public function testNoTypeCastingToDateWhenFlaggedSo()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'date'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01 12:19:01';
+        $format = null;
+        $doNotTypecastDateTime = true;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame($result, $value);
+    }
+}

--- a/test/Filter/ORMTypeCasterTest.php
+++ b/test/Filter/ORMTypeCasterTest.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Doctrine\QueryBuilder\Filter;
+
+use PHPUnit\Framework\TestCase;
+use ZF\Doctrine\QueryBuilder\Filter\ORM\TypeCaster;
+
+class ORMTypeCasterTest extends TestCase
+{
+    private $typeCaster;
+
+    protected function setUp()
+    {
+        $this->typeCaster = new TypeCaster();
+    }
+
+    public function testTypeCastingToString()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'string'
+            ],
+        ];
+
+        $field = 'field';
+        $value = 1;
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+
+        $this->assertSame('1', $result);
+    }
+
+    public function testTypeCastingToInteger()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'integer'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2144211244';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(2144211244, $result);
+    }
+
+    public function testTypeCastingToSmallint()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'smallint'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(2, $result);
+    }
+
+    public function testTypeCastingToBoolean()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'boolean'
+            ],
+        ];
+
+        $field = 'field';
+        $value = 'abc';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(true, $result);
+
+        $value = 0;
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(false, $result);
+    }
+
+    public function testTypeCastingToDecimal()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'decimal'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '1.141';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(1.141, $result);
+    }
+
+    public function testTypeCastingToFloat()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'float'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '1.242';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame(1.242, $result);
+    }
+
+    public function testTypeCastingToDate()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'date'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertEquals($result->format('Y-m-d'), '2019-09-01');
+        $this->assertEquals($result->format('H:i:s'), '00:00:00');
+    }
+
+    public function testNoTypeCastingToDateWhenFlaggedSo()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'date'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01';
+        $format = null;
+        $doNotTypecastDateTime = true;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame($result, $value);
+    }
+
+    public function testTypeCastingToTime()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'time'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '12:01:55';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertEquals($result->format('H:i:s'), '12:01:55');
+    }
+
+    public function testNoTypeCastingToTimeWhenFlaggedSo()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'time'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '12:01:55';
+        $format = null;
+        $doNotTypecastDateTime = true;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame($result, $value);
+    }
+
+    public function testTypeCastingToDateTime()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'datetime'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01 12:03:44';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertEquals($result->format('Y-m-d'), '2019-09-01');
+        $this->assertEquals($result->format('H:i:s'), '12:03:44');
+    }
+
+    public function testNoTypeCastingToDateTimeWhenFlaggedSo()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'datetime'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01 12:03:44';
+        $format = null;
+        $doNotTypecastDateTime = true;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame($result, $value);
+    }
+
+    public function testTypeCastingForUnknownFieldType()
+    {
+        $metadata = new \stdClass();
+        $metadata->fieldMappings = [
+            'field' => [
+                'type' => 'some random type'
+            ],
+        ];
+
+        $field = 'field';
+        $value = '2019-09-01 12:03:44';
+        $format = null;
+        $doNotTypecastDateTime = false;
+
+        $result = $this->typeCaster->typeCastField($metadata, $field, $value, $format, $doNotTypecastDateTime);
+        $this->assertSame($result, $value);
+    }
+}


### PR DESCRIPTION
By extracting the type casting to its own class it can be easily replaced when needed. Preferring composition over inheritance etc.

 It becomes better testable as well.

I tried to keep BC by proxying to the TypeCaster and instantiating the TypeCaster in the AbstractFilter::getTypeCaster() method when not set in case FilterManager::filter() method is overridden.